### PR TITLE
Issue#17 Format date to ISO8601 with original datepicker.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ angular
   'ngMaterial',
   'pascalprecht.translate',
   'infinite-scroll',
-  'materialDatePicker'
+  'datePicker'
 ])
 .config(function($routeProvider, $mdThemingProvider) {
 

--- a/src/util/date-picker.js
+++ b/src/util/date-picker.js
@@ -1,0 +1,32 @@
+(function() {
+  'use strict';
+
+  var app;
+
+  app = angular.module('datePicker', ['mgcrea.ngStrap', 'ngMaterial', 'ui.utils']);
+
+  app.directive('mdDatePicker', [    
+    '$datepicker', function($datepicker) {      
+      return {
+        template: '<div class="md-toolbar-tools dark">' + ' <md-input-container ng-disabled="isDisabled">' + '     <label>{{label}}</label>' + '    <input data-date-format="yyyy-MM-dd" id="date-picker" model-view-value="true"' + '             ng-model="value" bs-datepicker></md-input>' + '</md-input-container>' + '</div>',
+        restrict: 'E',
+        scope: {
+          lineColor: "@",
+          textColor: "@",
+          mask: "@"
+        },
+        link: function(scope, element, attrs) {
+          var picker;
+          picker = $("#date-picker");
+          if (scope.textColor) {
+            picker.css("color", scope.textColor, "important");
+          }
+          if (scope.lineColor) {
+            picker.css("border-color", scope.lineColor, "important");
+          }
+        }
+      };
+    }
+  ]);
+
+}).call(this);


### PR DESCRIPTION
datepickerで選択した後に表示されるdate formatの対応。
material-date-pickerのdirectiveに手を入れる必要があったため、ng-managerアプリ配下にutilディレクトリを切って新たにdatepickerモジュールを配置しました。
実際に追加した箇所はsrc/util/date-picker.jsのL11  data-date-format="yyyy-MM-dd"です。