### PR TITLE
Fix cross origin

### DIFF
--- a/src/api/api-service.js
+++ b/src/api/api-service.js
@@ -167,12 +167,12 @@ angular
     }
   };
 })
-.factory('authHttpInterceptor', function ($q, $rootScope, $location, $endpointService) {
+.factory('authHttpInterceptor', function ($q, $rootScope, $location, $endpointService, $cookies) {
   return {
     'request': function(config) {
       var ep = $endpointService.getSelected();
 
-      if(!ep){
+      if (!ep) {
         return config || $q.when(config);
       }
 
@@ -183,11 +183,15 @@ angular
       }
 
       var token = _.find(tokens, { 'name': ep.name });
-      if(token){
-        config.headers = {
-          'X-XSRF-TOKEN': token.token
-        };
+      var headerName = 'X-XSRF-TOKEN';
+      if (token) {
+        config.headers[headerName] = token.token;
       }
+
+      if ($cookies['XSRF-TOKEN']) {
+        delete $cookies['XSRF-TOKEN'];
+      }
+
       return config || $q.when(config);
     },
     'responseError': function(rejection) {

--- a/src/api/api-service.js
+++ b/src/api/api-service.js
@@ -167,7 +167,7 @@ angular
     }
   };
 })
-.factory('authHttpInterceptor', function ($q, $rootScope, $location, $endpointService, $cookies) {
+.factory('authHttpInterceptor', function ($q, $rootScope, $location, $endpointService) {
   return {
     'request': function(config) {
       var ep = $endpointService.getSelected();
@@ -184,9 +184,9 @@ angular
 
       var token = _.find(tokens, { 'name': ep.name });
       if(token){
-        $cookies['XSRF-TOKEN'] = token.token;
-      } else {
-        $cookies['XSRF-TOKEN'] = null;
+        config.headers = {
+          'X-XSRF-TOKEN': token.token
+        };
       }
       return config || $q.when(config);
     },

--- a/src/entity/entity-controller.js
+++ b/src/entity/entity-controller.js
@@ -15,7 +15,7 @@ angular
     var kind = $routeParams.kind;
     var limit = 30;
     var loadCount = 1;
-    var isLoading = false;
+    var isLoading;
     var isSearch = false;
     var isFilter = false;
 
@@ -54,6 +54,9 @@ angular
     };
 
     $scope.list = function() {
+
+      isLoading = true;
+
       $entityService.list({
         kind: kind
       }).then(function(data) {
@@ -80,6 +83,8 @@ angular
 
         // update size after applying list
         setTimeout(resize, 0);
+
+        isLoading = false;
 
       }, function(err) {
         $errorService.showError(err);


### PR DESCRIPTION
# authトークンの渡し方を若干変更，およびsmallfix

## トークンに関して
angular標準のxsrfヘッダーをつけてくれるやつが
クロスオリジンのときにつけてくれないことがわかったので，
直接ヘッダーにつけるよう，変更しました．

## small fix
- 最初にentityを２回読んでしまっていた問題を解消．
